### PR TITLE
us-40 User Dotfiles aus Git entfernen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
-# Preconfigured
+# --- Preconfigured ---
 bin/
 obj/
 /packages/
 riderModule.iml
 /_ReSharperl.Caches/
 
-# Self-configured
+# --- Self-configured ---
+# IDE Settings
 .idea/
+# Rider User Settings
+voycar-backend.sln.DotSettings.user
+
 Logs/

--- a/voycar-backend.sln.DotSettings.user
+++ b/voycar-backend.sln.DotSettings.user
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=394ef96a_002D7c0f_002D4a98_002Daa37_002D11048c0c5202/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Tests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
-  &lt;TestAncestor&gt;
-    &lt;TestId&gt;xUnit::BF92D12A-AA47-4FA5-B204-38688EA4CB0B::net8.0::Voycar.Api.Web.Tests.Features.Name.Tests&lt;/TestId&gt;
-  &lt;/TestAncestor&gt;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
[User story](https://tree.taiga.io/project/julius-boettger-voycar/us/40)

Die Rider User Settings sind jetzt nicht mehr unter version control. Siehe [Rider Doku](https://www.jetbrains.com/help/rider/Sharing_Configuration_Options.html) zu näheren Informationen der `sln.DotSettings`

