### PR TITLE
us-50 Fix Docker Setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 ﻿services:
   voycar.api.web:
-    image: voycar.api.web
     container_name: VoycarWeb
     ports:
       - "8080:8080"


### PR DESCRIPTION
[User story 50](https://tree.taiga.io/project/julius-boettger-voycar/us/50)

Bei Starten der Docker Images über Docker Compose kam eine Fehlermeldung, da das Docker image `voycar.api.web` nicht gepulled werden konnte. Wir wollen jedoch auch kein image pullen, für loakle builds wird daher kein image Name benötigt.

## WSL Setup
Bezüglich der permissions Fehlermeldung im Zusammenhang mit Docker in WSL: "initdb: error: could not change permissions of directory "/var/lib/postgresql/data": Operation not permitted". Diese konnte ich über eine WSL Config lösen.br>
Hierzu in `/etc/wsl.conf` den Eintrag
```bash
[automount]
enabled = true
options = "metadata"
```
Credits gehen an https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly und siehe auch die Doku zur `wsl.conf` https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-options<br>
Danach einmal wsl neustarten:
```
wsl --shutdown
wsl
```