### PR TITLE
us-95 Swagger Dokumentation erzeugt falschen Statuscode

### DIFF
--- a/Voycar.Api.Web/Features/Members/Get/Verify/Endpoint.cs
+++ b/Voycar.Api.Web/Features/Members/Get/Verify/Endpoint.cs
@@ -22,11 +22,6 @@ public class Endpoint : Endpoint<Request>
     {
         this.Get("/verify/{verificationToken}");
         this.AllowAnonymous();
-        this.Description(b => b
-                .Accepts<Request>("Voycar.Api.Web/Generic/Entity")
-                .Produces<IResult>(200)
-                .ProducesProblem(400),
-            clearDefaults: true);
         this.Summary(s =>
         {
             s.Summary = "Verify Member";

--- a/Voycar.Api.Web/Generic/Endpoint/Delete/Single.cs
+++ b/Voycar.Api.Web/Generic/Endpoint/Delete/Single.cs
@@ -19,11 +19,6 @@ public abstract class Single<TEntity>
     {
         this.Delete(typeof(TEntity).Name.ToLowerInvariant() + "/{id}");
         this.Roles(this.roles);
-        this.Description(b => b
-                .Accepts<Entity>("Voycar.Api.Web/Generic/Entity")
-                .Produces<IResult>(200)
-                .ProducesProblem(404),
-            clearDefaults: true);
         this.Summary(s =>
         {
             s.Summary = $"Delete {typeof(TEntity).Name}";

--- a/Voycar.Api.Web/Generic/Endpoint/Get/Single.cs
+++ b/Voycar.Api.Web/Generic/Endpoint/Get/Single.cs
@@ -19,11 +19,6 @@ public abstract class Single<TEntity>
     {
         this.Get(typeof(TEntity).Name.ToLowerInvariant() + "/{id}");
         this.Roles(this.roles);
-        this.Description(b => b
-                .Accepts<Entity>("Voycar.Api.Web/Generic/Entity")
-                .Produces<TEntity>(200)
-                .ProducesProblem(404),
-            clearDefaults: true);
         this.Summary(s =>
         {
             s.Summary = $"Retrieve {typeof(TEntity).Name}";

--- a/Voycar.Api.Web/Generic/Endpoint/Post/Single.cs
+++ b/Voycar.Api.Web/Generic/Endpoint/Post/Single.cs
@@ -19,12 +19,6 @@ public abstract class Single<TEntity>
     {
         this.Post(typeof(TEntity).Name.ToLowerInvariant());
         this.Roles(this.roles);
-        this.Description(b => b
-                .Accepts<TEntity>("Voycar.Api.Web/Generic/Entity")
-                .Produces<IResult>(200)
-                .ProducesProblem(204)
-                .ProducesProblem(404),
-            clearDefaults: true);
         this.Summary(s =>
         {
             s.Summary = $"Create {typeof(TEntity).Name}";

--- a/Voycar.Api.Web/Generic/Endpoint/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Generic/Endpoint/Post/SingleUnique.cs
@@ -16,12 +16,6 @@ public abstract class SingleUnique<TEntity>
     {
         this.Post(typeof(TEntity).Name.ToLowerInvariant());
         this.Roles(this.roles);
-        this.Description(b => b
-                .Accepts<TEntity>("Voycar.Api.Web/Generic/Entity")
-                .Produces<IResult>(200)
-                .ProducesProblem(204)
-                .ProducesProblem(404),
-            clearDefaults: true);
         this.Summary(s =>
         {
             s.Summary = $"Create unique {typeof(TEntity).Name}";

--- a/Voycar.Api.Web/Generic/Endpoint/Put/Single.cs
+++ b/Voycar.Api.Web/Generic/Endpoint/Put/Single.cs
@@ -19,11 +19,6 @@ public abstract class Single<TEntity>
     {
         this.Put(typeof(TEntity).Name.ToLowerInvariant());
         this.Roles(this.roles);
-        this.Description(b => b
-                .Accepts<TEntity>("Voycar.Api.Web/Generic/Entity")
-                .Produces<IResult>(200)
-                .ProducesProblem(404),
-            clearDefaults: true);
         this.Summary(s =>
         {
             s.Summary = $"Update {typeof(TEntity).Name}";
@@ -31,7 +26,6 @@ public abstract class Single<TEntity>
             s.Responses[200] = "If PUT operation is successful";
             s.Responses[404] =
                 "If PUT operation is performed for an Entity that could not be found in the database or requesting user isn't authorized";
-            s.ResponseExamples[404] = new {};
         });
     }
 


### PR DESCRIPTION
[User story 95](https://tree.taiga.io/project/julius-boettger-voycar/us/95)

Die default Description (Metadata) der Swagger Dokumentation brauchen wir eigentlich nicht überschreiben. Die habe ich jetzt rausgenommen.

