### PR TITLE
us-96 Falscher Status Code bei fehlender Autorisierung

### DIFF
--- a/Voycar.Api.Web/Generic/Endpoint/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Generic/Endpoint/Post/SingleUnique.cs
@@ -23,7 +23,6 @@ public abstract class SingleUnique<TEntity>
             s.Responses[200] = "If POST operation is successful";
             s.Responses[204] =
                 $"If POST operation failed or the same {typeof(TEntity).Name} object is already present in the database";
-            s.Responses[404] = "If requesting user isn't authorized";
         });
     }
 

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -78,7 +78,28 @@ try
     app.UseSerilogRequestLogging()
        .UseAuthentication()
        .UseAuthorization()
-       .UseFastEndpoints()
+       .UseFastEndpoints(c =>
+       {
+           c.Endpoints.Configurator = ep =>
+           {
+               // Setup Swagger Documentation for all endpoints which require a role for accessing
+               if (ep.AllowedRoles?.Count == 0)
+               {
+                   return;
+               }
+
+               ep.Description(b =>
+               {
+                   b.Produces(401); // Unauthorized -> if user is not logged in
+                   b.Produces(403); // Forbidden -> if user is missing roles
+               });
+               ep.Summary(s =>
+               {
+                   s.Responses[401] = "If requesting user isn't authorized";
+                   s.Responses[403] = "If requesting user doesn't have the required roles";
+               });
+           };
+       })
        .UseSwaggerGen();
 
     app.Run();


### PR DESCRIPTION
[User story 96](https://tree.taiga.io/project/julius-boettger-voycar/us/96)

Die CookieAuthentifzierungsmiddleware wurde überschrieben, damit bei nicht autorisierten users/requests die richtigen Statuscodes `401` und `403` geschickt werden. Wie es auch eigentlich in der Fastendpoints [Dokumenation](https://fast-endpoints.com/docs/swagger-support#describe-endpoints) beschrieben steht. 
Zusätzlich werden diese Stauscodes in die Swaggerdokumentation eingefügt.

Zusätzlich ist der Logintimout jetzt 10 Minuten anstatt 1.