### PR TITLE
us-100 Alle Endpunkte haben 401 und 403 Dokumentation

### DIFF
--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -83,7 +83,7 @@ try
            c.Endpoints.Configurator = ep =>
            {
                // Setup Swagger Documentation for all endpoints which require a role for accessing
-               if (ep.AllowedRoles?.Count == 0)
+               if (ep.AllowedRoles is null || ep.AllowedRoles.Count == 0)
                {
                    return;
                }


### PR DESCRIPTION
[User story 100](https://tree.taiga.io/project/julius-boettger-voycar/us/100)
Für #27 haben wir wohl nicht ganz sauber getestet (upsi) 😅 Auf einmal wurden im Swagger bei allen Endpunkten die 401 und 403 Statuscodes angezeigt. Ist hiermit behoben und nur bei den Endpunkten, die eine Rolle benötigen, vorhanden. 

