### PR TITLE
us-128 CRUD Endpoints für restliche Entities anlegen

### DIFF
--- a/Voycar.Api.Web/Entities/Car.cs
+++ b/Voycar.Api.Web/Entities/Car.cs
@@ -1,6 +1,7 @@
 namespace Voycar.Api.Web.Entities;
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using Generic;
 
 public class Car : Entity
@@ -15,5 +16,6 @@ public class Car : Entity
 
     [ForeignKey("Station")]
     public Guid StationId { get; set; }
+    [JsonIgnore]
     public Station Station { get; set; }
 }

--- a/Voycar.Api.Web/Entities/Reservation.cs
+++ b/Voycar.Api.Web/Entities/Reservation.cs
@@ -1,6 +1,7 @@
 namespace Voycar.Api.Web.Entities;
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using Generic;
 
 public class Reservation : Entity
@@ -10,9 +11,11 @@ public class Reservation : Entity
 
     [ForeignKey("Member")]
     public Guid MemberId { get; set; }
+    [JsonIgnore]
     public Member Member { get; set; }
 
     [ForeignKey("Car")]
     public Guid CarId { get; set; }
+    [JsonIgnore]
     public Car Car { get; set; }
 }

--- a/Voycar.Api.Web/Entities/Station.cs
+++ b/Voycar.Api.Web/Entities/Station.cs
@@ -1,6 +1,7 @@
 namespace Voycar.Api.Web.Entities;
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using Generic;
 
 public class Station : Entity
@@ -11,5 +12,6 @@ public class Station : Entity
 
     [ForeignKey("City")]
     public Guid CityId { get; set; }
+    [JsonIgnore]
     public City City { get; set; }
 }

--- a/Voycar.Api.Web/Features/Cars/Endpoints/Delete/Single.cs
+++ b/Voycar.Api.Web/Features/Cars/Endpoints/Delete/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cars.Endpoints.Delete;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Delete.Single<Car>
+{
+    // ToDo roles
+    public Single(ICars repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cars/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Cars/Endpoints/Get/All.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cars.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class All : Generic.Endpoint.Get.All<Car>
+{
+    // ToDo roles
+    public All(ICars repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cars/Endpoints/Get/Single.cs
+++ b/Voycar.Api.Web/Features/Cars/Endpoints/Get/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cars.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Get.Single<Car>
+{
+    // ToDo roles
+    public Single(ICars repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cars/Endpoints/Post/Single.cs
+++ b/Voycar.Api.Web/Features/Cars/Endpoints/Post/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cars.Endpoints.Post;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Post.Single<Car>
+{
+    // ToDo roles
+    public Single(ICars repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cars/Endpoints/Put/Single.cs
+++ b/Voycar.Api.Web/Features/Cars/Endpoints/Put/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cars.Endpoints.Put;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Put.Single<Car>
+{
+    // ToDo roles
+    public Single(ICars repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cars/Repository/Cars.cs
+++ b/Voycar.Api.Web/Features/Cars/Repository/Cars.cs
@@ -1,0 +1,9 @@
+namespace Voycar.Api.Web.Features.Cars.Repository;
+
+using Context;
+using Entities;
+
+public class Cars : Generic.Repository.Repository<Car>, ICars
+{
+    public Cars(VoycarDbContext context) : base(context) {}
+}

--- a/Voycar.Api.Web/Features/Cars/Repository/ICars.cs
+++ b/Voycar.Api.Web/Features/Cars/Repository/ICars.cs
@@ -1,0 +1,5 @@
+namespace Voycar.Api.Web.Features.Cars.Repository;
+
+using Entities;
+
+public interface ICars : Generic.Repository.IRepository<Car>;

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Delete/Single.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Delete/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cities.Endpoints.Delete;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Delete.Single<City>
+{
+    // ToDo roles
+    public Single(ICities repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Get/All.cs
@@ -7,4 +7,11 @@ public class All : Generic.Endpoint.Get.All<City>
 {
     // ToDo roles
     public All(ICities repository) : base(repository, ["admin"]) {}
+
+    public override void Configure()
+    {
+        base.Configure();
+        // Manually correct grammar
+        this.Summary(s => s.Summary = $"Retrieve all Cities");
+    }
 }

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Get/All.cs
@@ -12,6 +12,6 @@ public class All : Generic.Endpoint.Get.All<City>
     {
         base.Configure();
         // Manually correct grammar
-        this.Summary(s => s.Summary = $"Retrieve all Cities");
+        this.Summary(s => s.Summary = "Retrieve all Cities");
     }
 }

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Get/All.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cities.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class All : Generic.Endpoint.Get.All<City>
+{
+    // ToDo roles
+    public All(ICities repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Get/Single.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Get/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cities.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Get.Single<City>
+{
+    // ToDo roles
+    public Single(ICities repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Post/SingleUnique.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cities.Endpoints.Post;
+
+using Entities;
+using Repository;
+
+public class SingleUnique : Generic.Endpoint.Post.SingleUnique<City>
+{
+    // ToDo roles
+    public SingleUnique(ICities repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cities/Endpoints/Put/Single.cs
+++ b/Voycar.Api.Web/Features/Cities/Endpoints/Put/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Cities.Endpoints.Put;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Put.Single<City>
+{
+    // ToDo roles
+    public Single(ICities repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Cities/Repository/Cities.cs
+++ b/Voycar.Api.Web/Features/Cities/Repository/Cities.cs
@@ -1,0 +1,9 @@
+namespace Voycar.Api.Web.Features.Cities.Repository;
+
+using Context;
+using Entities;
+
+public class Cities : Generic.Repository.Repository<City>, ICities
+{
+    public Cities(VoycarDbContext context) : base(context) {}
+}

--- a/Voycar.Api.Web/Features/Cities/Repository/ICities.cs
+++ b/Voycar.Api.Web/Features/Cities/Repository/ICities.cs
@@ -1,0 +1,5 @@
+namespace Voycar.Api.Web.Features.Cities.Repository;
+
+using Entities;
+
+public interface ICities : Generic.Repository.IRepository<City>;

--- a/Voycar.Api.Web/Features/Members/Repository/Members.cs
+++ b/Voycar.Api.Web/Features/Members/Repository/Members.cs
@@ -13,18 +13,12 @@ using Context;
 /// </summary>
 public class Members : Generic.Repository.Repository<Member>, IMembers
 {
-    private readonly VoycarDbContext _context;
-
-
-    public Members(VoycarDbContext context) : base(context)
-    {
-        _context = context;
-    }
+    public Members(VoycarDbContext context) : base(context) {}
 
 
     public Task<Member?> Retrieve(string verificationToken)
     {
-        return this._context.Members.FirstOrDefaultAsync(
+        return this.dbSet.FirstOrDefaultAsync(
             member => member.VerificationToken == verificationToken);
     }
 

--- a/Voycar.Api.Web/Features/Members/Repository/Users.cs
+++ b/Voycar.Api.Web/Features/Members/Repository/Users.cs
@@ -7,23 +7,17 @@ using Microsoft.EntityFrameworkCore;
 
 public class Users : Generic.Repository.Repository<User>, IUsers
 {
-    private readonly VoycarDbContext _context;
-
-
-    public Users(VoycarDbContext context) : base(context)
-    {
-        _context = context;
-    }
+    public Users(VoycarDbContext context) : base(context) {}
 
 
     public Task<User?> Retrieve(string attribute, string? value)
     {
         return attribute switch
         {
-            "email" => this._context.Users.FirstOrDefaultAsync(
+            "email" => this.dbSet.FirstOrDefaultAsync(
                 user => user.Email == value),
 
-            "passwordResetToken" => this._context.Users.FirstOrDefaultAsync(
+            "passwordResetToken" => this.dbSet.FirstOrDefaultAsync(
                 user => user.PasswordResetToken == value),
 
             _ => throw new ArgumentException("Invalid property name", nameof(attribute))

--- a/Voycar.Api.Web/Features/Plans/Endpoints/Delete/Single.cs
+++ b/Voycar.Api.Web/Features/Plans/Endpoints/Delete/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Plans.Endpoints.Delete;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Delete.Single<Plan>
+{
+    // ToDo roles
+    public Single(IPlans repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Plans/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Plans/Endpoints/Get/All.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Plans.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class All : Generic.Endpoint.Get.All<Plan>
+{
+    // ToDo roles
+    public All(IPlans repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Plans/Endpoints/Get/Single.cs
+++ b/Voycar.Api.Web/Features/Plans/Endpoints/Get/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Plans.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Get.Single<Plan>
+{
+    // ToDo roles
+    public Single(IPlans repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Plans/Endpoints/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Features/Plans/Endpoints/Post/SingleUnique.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Plans.Endpoints.Post;
+
+using Entities;
+using Repository;
+
+public class SingleUnique : Generic.Endpoint.Post.SingleUnique<Plan>
+{
+    // ToDo roles
+    public SingleUnique(IPlans repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Plans/Endpoints/Put/Single.cs
+++ b/Voycar.Api.Web/Features/Plans/Endpoints/Put/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Plans.Endpoints.Put;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Put.Single<Plan>
+{
+    // ToDo roles
+    public Single(IPlans repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Plans/Repository/IPlans.cs
+++ b/Voycar.Api.Web/Features/Plans/Repository/IPlans.cs
@@ -1,0 +1,5 @@
+namespace Voycar.Api.Web.Features.Plans.Repository;
+
+using Entities;
+
+public interface IPlans : Generic.Repository.IRepository<Plan>;

--- a/Voycar.Api.Web/Features/Plans/Repository/Plans.cs
+++ b/Voycar.Api.Web/Features/Plans/Repository/Plans.cs
@@ -1,0 +1,9 @@
+namespace Voycar.Api.Web.Features.Plans.Repository;
+
+using Context;
+using Entities;
+
+public class Plans : Generic.Repository.Repository<Plan>, IPlans
+{
+    public Plans(VoycarDbContext context) : base(context) {}
+}

--- a/Voycar.Api.Web/Features/Reservation/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Reservation/Endpoints/Get/All.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class All : Generic.Endpoint.Get.All<Reservation>
+{
+    // ToDo roles
+    public All(IReservations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Reservation/Endpoints/Get/Single.cs
+++ b/Voycar.Api.Web/Features/Reservation/Endpoints/Get/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Get.Single<Reservation>
+{
+    // ToDo roles
+    public Single(IReservations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Reservation/Repository/IReservations.cs
+++ b/Voycar.Api.Web/Features/Reservation/Repository/IReservations.cs
@@ -1,0 +1,5 @@
+namespace Voycar.Api.Web.Features.Reservation.Repository;
+
+using Entities;
+
+public interface IReservations : Generic.Repository.IRepository<Reservation>;

--- a/Voycar.Api.Web/Features/Reservation/Repository/Reservations.cs
+++ b/Voycar.Api.Web/Features/Reservation/Repository/Reservations.cs
@@ -1,0 +1,9 @@
+namespace Voycar.Api.Web.Features.Reservation.Repository;
+
+using Context;
+using Entities;
+
+public class Reservations : Generic.Repository.Repository<Reservation>, IReservations
+{
+    public Reservations(VoycarDbContext context) : base(context) {}
+}

--- a/Voycar.Api.Web/Features/Roles/Endpoints/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Features/Roles/Endpoints/Post/SingleUnique.cs
@@ -6,5 +6,5 @@ using Repository;
 public class SingleUnique : Generic.Endpoint.Post.SingleUnique<Role>
 {
     // ToDo roles
-    public SingleUnique(IRoles roles) : base(roles, ["admin"]) {}
+    public SingleUnique(IRoles repository) : base(repository, ["admin"]) {}
 }

--- a/Voycar.Api.Web/Features/Roles/Endpoints/Put/Single.cs
+++ b/Voycar.Api.Web/Features/Roles/Endpoints/Put/Single.cs
@@ -6,5 +6,5 @@ using Repository;
 public class Single : Generic.Endpoint.Put.Single<Role>
 {
     // ToDo roles
-    public Single(IRoles roles) : base(roles, ["admin"]) {}
+    public Single(IRoles repository) : base(repository, ["admin"]) {}
 }

--- a/Voycar.Api.Web/Features/Roles/Repository/Roles.cs
+++ b/Voycar.Api.Web/Features/Roles/Repository/Roles.cs
@@ -6,16 +6,11 @@ using Microsoft.EntityFrameworkCore;
 
 public class Roles : Generic.Repository.Repository<Role>, IRoles
 {
-    private readonly VoycarDbContext _context;
-
-    public Roles(VoycarDbContext context) : base(context)
-    {
-        this._context = context;
-    }
+    public Roles(VoycarDbContext context) : base(context) {}
 
     public Task<Role?> Retrieve(string name)
     {
-        return this._context.Roles.FirstOrDefaultAsync(
+        return this.dbSet.FirstOrDefaultAsync(
             role => role.Name == name);
     }
 }

--- a/Voycar.Api.Web/Features/Stations/Endpoints/Delete/Single.cs
+++ b/Voycar.Api.Web/Features/Stations/Endpoints/Delete/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Stations.Endpoints.Delete;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Delete.Single<Station>
+{
+    // ToDo roles
+    public Single(IStations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Stations/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Stations/Endpoints/Get/All.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Stations.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class All : Generic.Endpoint.Get.All<Station>
+{
+    // ToDo roles
+    public All(IStations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Stations/Endpoints/Get/Single.cs
+++ b/Voycar.Api.Web/Features/Stations/Endpoints/Get/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Stations.Endpoints.Get;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Get.Single<Station>
+{
+    // ToDo roles
+    public Single(IStations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Stations/Endpoints/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Features/Stations/Endpoints/Post/SingleUnique.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Stations.Endpoints.Post;
+
+using Entities;
+using Repository;
+
+public class SingleUnique : Generic.Endpoint.Post.SingleUnique<Station>
+{
+    // ToDo roles
+    public SingleUnique(IStations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Stations/Endpoints/Put/Single.cs
+++ b/Voycar.Api.Web/Features/Stations/Endpoints/Put/Single.cs
@@ -1,0 +1,10 @@
+namespace Voycar.Api.Web.Features.Stations.Endpoints.Put;
+
+using Entities;
+using Repository;
+
+public class Single : Generic.Endpoint.Put.Single<Station>
+{
+    // ToDo roles
+    public Single(IStations repository) : base(repository, ["admin"]) {}
+}

--- a/Voycar.Api.Web/Features/Stations/Repository/IStations.cs
+++ b/Voycar.Api.Web/Features/Stations/Repository/IStations.cs
@@ -1,0 +1,5 @@
+namespace Voycar.Api.Web.Features.Stations.Repository;
+
+using Entities;
+
+public interface IStations : Generic.Repository.IRepository<Station>;

--- a/Voycar.Api.Web/Features/Stations/Repository/Stations.cs
+++ b/Voycar.Api.Web/Features/Stations/Repository/Stations.cs
@@ -1,0 +1,9 @@
+namespace Voycar.Api.Web.Features.Stations.Repository;
+
+using Context;
+using Entities;
+
+public class Stations : Generic.Repository.Repository<Station>, IStations
+{
+    public Stations(VoycarDbContext context) : base(context) {}
+}

--- a/Voycar.Api.Web/Generic/Repository/Repository.cs
+++ b/Voycar.Api.Web/Generic/Repository/Repository.cs
@@ -6,8 +6,8 @@ using Context;
 
 public class Repository<TEntity> : IRepository<TEntity> where TEntity : Entity
 {
-    private readonly VoycarDbContext _context;
-    private readonly DbSet<TEntity> dbSet;
+    protected readonly VoycarDbContext _context;
+    protected readonly DbSet<TEntity> dbSet;
 
     protected Repository(VoycarDbContext context)
     {

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
 using Voycar.Api.Web.Context;
 using Voycar.Api.Web.Features.Cars.Repository;
+using Voycar.Api.Web.Features.Cities.Repository;
 using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Members.Repository;
 using Voycar.Api.Web.Features.Members.Services.EmailService;
@@ -58,6 +59,7 @@ try
     builder.Services.AddTransient<IMembers, Members>();
     builder.Services.AddTransient<IUsers, Users>();
     builder.Services.AddTransient<ICars, Cars>();
+    builder.Services.AddTransient<ICities, Cities>();
 
     // Services
     builder.Services.AddTransient<IEmailService, EmailService>();

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -2,6 +2,7 @@ using FastEndpoints.Security;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
 using Voycar.Api.Web.Context;
+using Voycar.Api.Web.Features.Cars.Repository;
 using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Members.Repository;
 using Voycar.Api.Web.Features.Members.Services.EmailService;
@@ -56,6 +57,7 @@ try
     builder.Services.AddTransient<IRoles, Roles>();
     builder.Services.AddTransient<IMembers, Members>();
     builder.Services.AddTransient<IUsers, Users>();
+    builder.Services.AddTransient<ICars, Cars>();
 
     // Services
     builder.Services.AddTransient<IEmailService, EmailService>();

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -7,6 +7,7 @@ using Voycar.Api.Web.Features.Cities.Repository;
 using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Members.Repository;
 using Voycar.Api.Web.Features.Members.Services.EmailService;
+using Voycar.Api.Web.Features.Plans.Repository;
 
 try
 {
@@ -60,6 +61,7 @@ try
     builder.Services.AddTransient<IUsers, Users>();
     builder.Services.AddTransient<ICars, Cars>();
     builder.Services.AddTransient<ICities, Cities>();
+    builder.Services.AddTransient<IPlans, Plans>();
 
     // Services
     builder.Services.AddTransient<IEmailService, EmailService>();

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -8,6 +8,7 @@ using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Members.Repository;
 using Voycar.Api.Web.Features.Members.Services.EmailService;
 using Voycar.Api.Web.Features.Plans.Repository;
+using Voycar.Api.Web.Features.Reservation.Repository;
 using Voycar.Api.Web.Features.Stations.Repository;
 
 try
@@ -64,6 +65,7 @@ try
     builder.Services.AddTransient<ICities, Cities>();
     builder.Services.AddTransient<IPlans, Plans>();
     builder.Services.AddTransient<IStations, Stations>();
+    builder.Services.AddTransient<IReservations, Reservations>();
 
     // Services
     builder.Services.AddTransient<IEmailService, EmailService>();

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -8,6 +8,7 @@ using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Members.Repository;
 using Voycar.Api.Web.Features.Members.Services.EmailService;
 using Voycar.Api.Web.Features.Plans.Repository;
+using Voycar.Api.Web.Features.Stations.Repository;
 
 try
 {
@@ -62,6 +63,7 @@ try
     builder.Services.AddTransient<ICars, Cars>();
     builder.Services.AddTransient<ICities, Cities>();
     builder.Services.AddTransient<IPlans, Plans>();
+    builder.Services.AddTransient<IStations, Stations>();
 
     // Services
     builder.Services.AddTransient<IEmailService, EmailService>();

--- a/Voycar.Api.Web/Voycar.Api.Web.csproj
+++ b/Voycar.Api.Web/Voycar.Api.Web.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Features\Cars\" />
     <Folder Include="Features\Cities\" />
     <Folder Include="Features\Members\Get\"/>
     <Folder Include="Features\Plans\" />

--- a/Voycar.Api.Web/Voycar.Api.Web.csproj
+++ b/Voycar.Api.Web/Voycar.Api.Web.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Features\Cities\" />
     <Folder Include="Features\Members\Get\"/>
     <Folder Include="Features\Plans\" />
     <Folder Include="Features\Reservation\" />

--- a/Voycar.Api.Web/Voycar.Api.Web.csproj
+++ b/Voycar.Api.Web/Voycar.Api.Web.csproj
@@ -33,6 +33,5 @@
 
   <ItemGroup>
     <Folder Include="Features\Members\Get\"/>
-    <Folder Include="Features\Reservation\" />
   </ItemGroup>
 </Project>

--- a/Voycar.Api.Web/Voycar.Api.Web.csproj
+++ b/Voycar.Api.Web/Voycar.Api.Web.csproj
@@ -34,6 +34,5 @@
   <ItemGroup>
     <Folder Include="Features\Members\Get\"/>
     <Folder Include="Features\Reservation\" />
-    <Folder Include="Features\Stations\" />
   </ItemGroup>
 </Project>

--- a/Voycar.Api.Web/Voycar.Api.Web.csproj
+++ b/Voycar.Api.Web/Voycar.Api.Web.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <Folder Include="Features\Members\Get\"/>
-    <Folder Include="Features\Plans\" />
     <Folder Include="Features\Reservation\" />
     <Folder Include="Features\Stations\" />
   </ItemGroup>


### PR DESCRIPTION
[User story 128](https://tree.taiga.io/project/julius-boettger-voycar/us/128)

Habe jetzt für alle neuen Entities (außer Reservation) alle CRUD Endpoints angelegt.

Für Reservation habe ich erstmal nur die `GET`-Endpoints gemacht, weil wir die anderen (`POST`/`PUT`/`DELETE`) vermutlich nicht so stumpf wollen, da muss ja noch mehr Logik rein.

