### PR TITLE
us-139 Unittest für Register-Endpoint schreiben

### DIFF
--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -20,8 +20,9 @@ public class Endpoint : TestBase<App>
     private readonly ILogger fakeLogger = A.Fake<ILogger<Endpoint>>();
 
 
-    private Features.Users.Endpoints.Post.Register.Endpoint SetupEndpoint() =>
-        Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
+    private Features.Users.Endpoints.Post.Register.Endpoint SetupEndpoint()
+    {
+        return Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
         {
             ctx.AddTestServices(s =>
             {
@@ -32,6 +33,8 @@ public class Endpoint : TestBase<App>
                 s.AddSingleton(this.fakeLogger);
             });
         });
+    }
+
 
 
     [Fact]

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -36,7 +36,6 @@ public class Endpoint : TestBase<App>
     }
 
 
-
     [Fact]
     public async Task Register_New_User_Successful_And_Return_Ok()
     {

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -11,20 +11,22 @@ using Voycar.Api.Web.Features.Users.Endpoints.Post.Register;
 using Voycar.Api.Web.Features.Users.Repository;
 using Service;
 
+
 public class Endpoint : TestBase<App>
 {
-    private readonly IMembers fakeMemberRepository = A.Fake<IMembers>();
-    private readonly IUsers fakeUserRepository = A.Fake<IUsers>();
-    private readonly IRoles fakeRoleRepository = A.Fake<IRoles>();
-    private readonly IEmailService fakeEmailService = A.Fake<IEmailService>();
-    private readonly ILogger fakeLogger = A.Fake<ILogger<Endpoint>>();
+    private readonly IMembers FakeMemberRepository = A.Fake<IMembers>();
+    private readonly IUsers FakeUserRepository = A.Fake<IUsers>();
+    private readonly IRoles FakeRoleRepository = A.Fake<IRoles>();
+    private readonly IEmailService FakeEmailService = A.Fake<IEmailService>();
+    private readonly ILogger FakeLogger = A.Fake<ILogger<Endpoint>>();
 
-    private readonly Request request = new()
+    private readonly Request Request = new()
     {
         Email = "test@test.de",
         Password = "notsafe987",
         BirthDate = new DateOnly(2000, 12, 12),
     };
+
 
     private Features.Users.Endpoints.Post.Register.Endpoint SetupEndpoint()
     {
@@ -32,11 +34,11 @@ public class Endpoint : TestBase<App>
         {
             ctx.AddTestServices(s =>
             {
-                s.AddSingleton(this.fakeUserRepository);
-                s.AddSingleton(this.fakeMemberRepository);
-                s.AddSingleton(this.fakeRoleRepository);
-                s.AddSingleton(this.fakeEmailService);
-                s.AddSingleton(this.fakeLogger);
+                s.AddSingleton(this.FakeUserRepository);
+                s.AddSingleton(this.FakeMemberRepository);
+                s.AddSingleton(this.FakeRoleRepository);
+                s.AddSingleton(this.FakeEmailService);
+                s.AddSingleton(this.FakeLogger);
             });
         });
     }
@@ -50,17 +52,17 @@ public class Endpoint : TestBase<App>
 
         var ep = this.SetupEndpoint();
 
-        var member = ep.Map.ToEntity(this.request);
-        var user = new User { Email = this.request.Email, PasswordHash = "hashedPassword" };
+        var member = ep.Map.ToEntity(this.Request);
+        var user = new User { Email = this.Request.Email, PasswordHash = "hashedPassword" };
 
-        A.CallTo(() => this.fakeUserRepository.RetrieveByEmail(this.request.Email)).Returns((User?)null);
-        A.CallTo(() => this.fakeRoleRepository.Retrieve(fakeRole.Name)).Returns(fakeRole);
-        A.CallTo(() => this.fakeMemberRepository.Create(member)).Returns(member.Id);
-        A.CallTo(() => this.fakeUserRepository.Create(user)).Returns(user.Id);
-        A.CallTo(() => this.fakeEmailService.SendVerificationEmail(user)).DoesNothing();
+        A.CallTo(() => this.FakeUserRepository.RetrieveByEmail(this.Request.Email)).Returns((User?)null);
+        A.CallTo(() => this.FakeRoleRepository.Retrieve(fakeRole.Name)).Returns(fakeRole);
+        A.CallTo(() => this.FakeMemberRepository.Create(member)).Returns(member.Id);
+        A.CallTo(() => this.FakeUserRepository.Create(user)).Returns(user.Id);
+        A.CallTo(() => this.FakeEmailService.SendVerificationEmail(user)).DoesNothing();
 
         // Act
-        await ep.HandleAsync(this.request, default);
+        await ep.HandleAsync(this.Request, default);
         var rsp = ep.HttpContext.Response;
 
         // Assert
@@ -74,12 +76,12 @@ public class Endpoint : TestBase<App>
     {
         // Arrange
         var ep = this.SetupEndpoint();
-        var user = new User { Email = this.request.Email, PasswordHash = "hashedPassword" };
+        var user = new User { Email = this.Request.Email, PasswordHash = "hashedPassword" };
 
-        A.CallTo(() => this.fakeUserRepository.RetrieveByEmail(this.request.Email)).Returns(user);
+        A.CallTo(() => this.FakeUserRepository.RetrieveByEmail(this.Request.Email)).Returns(user);
 
         // Act
-        await ep.HandleAsync(this.request, default);
+        await ep.HandleAsync(this.Request, default);
         var rsp = ep.HttpContext.Response;
 
         // Assert

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -1,15 +1,18 @@
 namespace Voycar.Api.Web.Tests.Unit.Users.Post.Register;
 
+using System.Text.Json;
 using Bogus.DataSets;
 using FakeItEasy;
+using Features.Members.Repository;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Voycar.Api.Web.Entities;
-using Voycar.Api.Web.Features.Members.Repository;
+using Voycar.Api.Web;
 using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Users.Endpoints.Post.Register;
 using Voycar.Api.Web.Features.Users.Repository;
 using Voycar.Api.Web.Service;
-
 
 public class Endpoint : TestBase<App>
 {
@@ -35,13 +38,23 @@ public class Endpoint : TestBase<App>
             PostalCode = "test",
             City = "test",
             Country = "test",
-            BirthDate = new DateOnly(2000,12,12),
+            BirthDate = new DateOnly(2000, 12, 12),
             BirthPlace = "test",
             PhoneNumber = "test"
         };
 
-        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(fakeUserRepository,
-            fakeMemberRepository, fakeRoleRepository, fakeEmailService, fakeLogger);
+
+        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
+        {
+            ctx.AddTestServices(s =>
+            {
+                s.AddSingleton(fakeUserRepository);
+                s.AddSingleton(fakeMemberRepository);
+                s.AddSingleton(fakeRoleRepository);
+                s.AddSingleton(fakeEmailService);
+                s.AddSingleton(fakeLogger);
+            });
+        });
 
         var member = ep.Map.ToEntity(req);
         var user = new User
@@ -57,18 +70,139 @@ public class Endpoint : TestBase<App>
         A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).Returns(fakeRole);
         A.CallTo(() => fakeMemberRepository.Create(member)).Returns(member.Id);
         A.CallTo(() => fakeUserRepository.Create(user)).Returns(user.Id);
+        A.CallTo(() => fakeEmailService.SendVerificationEmail(user)).DoesNothing();
+        // Act
+        await ep.HandleAsync(req, default);
+        var rsp = ep.HttpContext.Response;
+
+        // Assert
+
+        //A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).MustHaveHappenedOnceExactly();
+        //A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).MustHaveHappenedOnceOrMore();
+        //A.CallTo(() => fakeUserRepository.Create(user)).MustHaveHappenedOnceExactly();
+
+        Assert.NotNull(rsp);
+        Assert.Equal(StatusCodes.Status200OK, rsp.StatusCode);
+    }
 
 
+    [Fact]
+    public async Task RegisterUserFailureInvalidRequest()
+    {
+        // ToDo does not work yet
+        // Arrange
+        var fakeMemberRepository = A.Fake<IMembers>();
+        var fakeUserRepository = A.Fake<IUsers>();
+        var fakeRoleRepository = A.Fake<IRoles>();
+        var fakeEmailService = A.Fake<IEmailService>();
+        var fakeLogger = A.Fake<ILogger<Endpoint>>();
+
+        var req = new Request
+        {
+            Email = "invalidEmail",
+            Password = "notsafe987",
+            FirstName = "testFName",
+            LastName = "testLName",
+            Street = "test",
+            HouseNumber = "test",
+            PostalCode = "test",
+            City = "test",
+            Country = "test",
+            BirthDate = new DateOnly(2024, 1, 1),
+            BirthPlace = "test",
+            PhoneNumber = "test"
+        };
 
 
+        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
+        {
+            ctx.AddTestServices(s =>
+            {
+                s.AddSingleton(fakeUserRepository);
+                s.AddSingleton(fakeMemberRepository);
+                s.AddSingleton(fakeRoleRepository);
+                s.AddSingleton(fakeEmailService);
+                s.AddSingleton(fakeLogger);
+            });
+        });
+
+        var member = ep.Map.ToEntity(req);
 
 
-
-
-
+        A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email.ToLowerInvariant())).Returns((User?)null);
 
 
         // Act
+        await ep.HandleAsync(req, default);
+        var rsp = ep.HttpContext.Response;
+
         // Assert
+
+        //A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).MustHaveHappenedOnceExactly();
+        //A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).MustHaveHappenedOnceOrMore();
+        //A.CallTo(() => fakeUserRepository.Create(user)).MustHaveHappenedOnceExactly();
+
+        Assert.NotNull(rsp);
+        Assert.Equal(StatusCodes.Status400BadRequest, rsp.StatusCode);
+    }
+
+    [Fact]
+    public async Task RegisterUserFailureUserAlreadyExists()
+    {
+        // Arrange
+        var fakeMemberRepository = A.Fake<IMembers>();
+        var fakeUserRepository = A.Fake<IUsers>();
+        var fakeRoleRepository = A.Fake<IRoles>();
+        var fakeEmailService = A.Fake<IEmailService>();
+        var fakeLogger = A.Fake<ILogger<Endpoint>>();
+
+        var req = new Request
+        {
+            Email = "test@test.de",
+            Password = "notsafe987",
+            FirstName = "testFName",
+            LastName = "testLName",
+            Street = "test",
+            HouseNumber = "test",
+            PostalCode = "test",
+            City = "test",
+            Country = "test",
+            BirthDate = new DateOnly(2000, 12, 12),
+            BirthPlace = "test",
+            PhoneNumber = "test"
+        };
+
+
+        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
+        {
+            ctx.AddTestServices(s =>
+            {
+                s.AddSingleton(fakeUserRepository);
+                s.AddSingleton(fakeMemberRepository);
+                s.AddSingleton(fakeRoleRepository);
+                s.AddSingleton(fakeEmailService);
+                s.AddSingleton(fakeLogger);
+            });
+        });
+
+        var member = ep.Map.ToEntity(req);
+
+
+        A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email.ToLowerInvariant())).Returns(
+                new User { Email = "test@test.de", PasswordHash = "notsafe987Hash" });
+
+
+        // Act
+        await ep.HandleAsync(req, default);
+        var rsp = ep.HttpContext.Response;
+
+        // Assert
+
+        //A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).MustHaveHappenedOnceExactly();
+        //A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).MustHaveHappenedOnceOrMore();
+        //A.CallTo(() => fakeUserRepository.Create(user)).MustHaveHappenedOnceExactly();
+
+        Assert.NotNull(rsp);
+        Assert.Equal(StatusCodes.Status400BadRequest, rsp.StatusCode);
     }
 }

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -19,6 +19,12 @@ public class Endpoint : TestBase<App>
     private readonly IEmailService fakeEmailService = A.Fake<IEmailService>();
     private readonly ILogger fakeLogger = A.Fake<ILogger<Endpoint>>();
 
+    private readonly Request request = new()
+    {
+        Email = "test@test.de",
+        Password = "notsafe987",
+        BirthDate = new DateOnly(2000, 12, 12),
+    };
 
     private Features.Users.Endpoints.Post.Register.Endpoint SetupEndpoint()
     {
@@ -41,50 +47,20 @@ public class Endpoint : TestBase<App>
     {
         // Arrange
         var fakeRole = new Role { Id = new Guid("4ECB35CC-906C-46D7-AB3B-EDB468E1DD51"), Name = "member" };
-        var req = new Request
-        {
-            Email = "test@test.de",
-            Password = "notsafe987",
-            FirstName = "testFName",
-            LastName = "testLName",
-            Street = "test",
-            HouseNumber = "test",
-            PostalCode = "test",
-            City = "test",
-            Country = "test",
-            BirthDate = new DateOnly(2000, 12, 12),
-            BirthPlace = "test",
-            PhoneNumber = "test"
-        };
-
-        var mem = new Member
-        {
-            Id = new Guid("E5180CD2-A399-4EE3-AAE3-D909FA25AFF3"),
-            FirstName = "testFName",
-            LastName = "testLName",
-            Street = "test",
-            HouseNumber = "test",
-            PostalCode = "test",
-            City = "test",
-            Country = "test",
-            BirthDate = new DateOnly(2000, 12, 12),
-            BirthPlace = "test",
-            PhoneNumber = "test"
-        };
 
         var ep = this.SetupEndpoint();
 
-        var member = ep.Map.ToEntity(req);
-        var user = new User { Email = req.Email, PasswordHash = "hashedPassword" };
+        var member = ep.Map.ToEntity(this.request);
+        var user = new User { Email = this.request.Email, PasswordHash = "hashedPassword" };
 
-        A.CallTo(() => this.fakeUserRepository.RetrieveByEmail(req.Email)).Returns((User?)null);
+        A.CallTo(() => this.fakeUserRepository.RetrieveByEmail(this.request.Email)).Returns((User?)null);
         A.CallTo(() => this.fakeRoleRepository.Retrieve(fakeRole.Name)).Returns(fakeRole);
         A.CallTo(() => this.fakeMemberRepository.Create(member)).Returns(member.Id);
         A.CallTo(() => this.fakeUserRepository.Create(user)).Returns(user.Id);
         A.CallTo(() => this.fakeEmailService.SendVerificationEmail(user)).DoesNothing();
 
         // Act
-        await ep.HandleAsync(req, default);
+        await ep.HandleAsync(this.request, default);
         var rsp = ep.HttpContext.Response;
 
         // Assert
@@ -97,29 +73,13 @@ public class Endpoint : TestBase<App>
     public async Task Register_ExistingUser_Returns_BadRequest()
     {
         // Arrange
-        var req = new Request
-        {
-            Email = "test@test.de",
-            Password = "notsafe987",
-            FirstName = "testFName",
-            LastName = "testLName",
-            Street = "test",
-            HouseNumber = "test",
-            PostalCode = "test",
-            City = "test",
-            Country = "test",
-            BirthDate = new DateOnly(2000, 12, 12),
-            BirthPlace = "test",
-            PhoneNumber = "test"
-        };
-
         var ep = this.SetupEndpoint();
-        var user = new User { Email = req.Email, PasswordHash = "hashedPassword" };
+        var user = new User { Email = this.request.Email, PasswordHash = "hashedPassword" };
 
-        A.CallTo(() => this.fakeUserRepository.RetrieveByEmail(req.Email)).Returns(user);
+        A.CallTo(() => this.fakeUserRepository.RetrieveByEmail(this.request.Email)).Returns(user);
 
         // Act
-        await ep.HandleAsync(req, default);
+        await ep.HandleAsync(this.request, default);
         var rsp = ep.HttpContext.Response;
 
         // Assert

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -16,7 +16,7 @@ using Service;
 public class Endpoint : TestBase<App>
 {
     [Fact]
-    public async Task RegisterUserSuccessful()
+    public async Task Register_New_User_Successful_And_Return_Ok()
     {
         // Arrange
         var fakeMemberRepository = A.Fake<IMembers>();
@@ -89,7 +89,7 @@ public class Endpoint : TestBase<App>
 
 
     [Fact]
-    public async Task RegisterUserFailure_UserAlreadyExists()
+    public async Task Register_ExistingUser_Returns_BadRequest()
     {
         // Arrange
         var fakeMemberRepository = A.Fake<IMembers>();

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -1,0 +1,74 @@
+namespace Voycar.Api.Web.Tests.Unit.Users.Post.Register;
+
+using Bogus.DataSets;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Voycar.Api.Web.Entities;
+using Voycar.Api.Web.Features.Members.Repository;
+using Voycar.Api.Web.Features.Roles.Repository;
+using Voycar.Api.Web.Features.Users.Endpoints.Post.Register;
+using Voycar.Api.Web.Features.Users.Repository;
+using Voycar.Api.Web.Service;
+
+
+public class Endpoint : TestBase<App>
+{
+    [Fact]
+    public async Task RegisterUserSuccessful()
+    {
+        // Arrange
+        var fakeMemberRepository = A.Fake<IMembers>();
+        var fakeUserRepository = A.Fake<IUsers>();
+        var fakeRoleRepository = A.Fake<IRoles>();
+        var fakeEmailService = A.Fake<IEmailService>();
+        var fakeLogger = A.Fake<ILogger<Endpoint>>();
+
+        var fakeRole = new Role { Id = new Guid("4ECB35CC-906C-46D7-AB3B-EDB468E1DD51"), Name = "member" };
+        var req = new Request
+        {
+            Email = "test@test.de",
+            Password = "notsafe987",
+            FirstName = "testFName",
+            LastName = "testLName",
+            Street = "test",
+            HouseNumber = "test",
+            PostalCode = "test",
+            City = "test",
+            Country = "test",
+            BirthDate = new DateOnly(2000,12,12),
+            BirthPlace = "test",
+            PhoneNumber = "test"
+        };
+
+        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(fakeUserRepository,
+            fakeMemberRepository, fakeRoleRepository, fakeEmailService, fakeLogger);
+
+        var member = ep.Map.ToEntity(req);
+        var user = new User
+        {
+            Email = req.Email,
+            PasswordHash = "hashedPassword",
+            VerificationToken = "verificationToken",
+            RoleId = fakeRoleRepository.Retrieve(fakeRole.Name).Result!.Id
+        };
+
+
+        A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).Returns((User?)null);
+        A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).Returns(fakeRole);
+        A.CallTo(() => fakeMemberRepository.Create(member)).Returns(member.Id);
+        A.CallTo(() => fakeUserRepository.Create(user)).Returns(user.Id);
+
+
+
+
+
+
+
+
+
+
+
+        // Act
+        // Assert
+    }
+}

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -42,6 +42,21 @@ public class Endpoint : TestBase<App>
             PhoneNumber = "test"
         };
 
+        var mem = new Member
+        {
+            Id = new Guid("E5180CD2-A399-4EE3-AAE3-D909FA25AFF3"),
+            FirstName = "testFName",
+            LastName = "testLName",
+            Street = "test",
+            HouseNumber = "test",
+            PostalCode = "test",
+            City = "test",
+            Country = "test",
+            BirthDate = new DateOnly(2000, 12, 12),
+            BirthPlace = "test",
+            PhoneNumber = "test"
+        };
+
         var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
         {
             ctx.AddTestServices(s =>
@@ -53,6 +68,9 @@ public class Endpoint : TestBase<App>
                 s.AddSingleton(fakeLogger);
             });
         });
+
+        ep.Map = new Mapper();
+        A.CallTo(() => ep.Map.ToEntity(req)).Returns(mem);
 
         var member = ep.Map.ToEntity(req);
         var user = new User { Email = req.Email, PasswordHash = "hashedPassword"};
@@ -74,7 +92,7 @@ public class Endpoint : TestBase<App>
 
 
     [Fact]
-    public async Task RegisterUserFailure()
+    public async Task RegisterUserFailure_UserAlreadyExists()
     {
         // Arrange
         var fakeMemberRepository = A.Fake<IMembers>();

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -69,9 +69,6 @@ public class Endpoint : TestBase<App>
             });
         });
 
-        ep.Map = new Mapper();
-        A.CallTo(() => ep.Map.ToEntity(req)).Returns(mem);
-
         var member = ep.Map.ToEntity(req);
         var user = new User { Email = req.Email, PasswordHash = "hashedPassword"};
 

--- a/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
+++ b/Voycar.Api.Web.Tests.Unit/Users/Post/Register/Endpoint.cs
@@ -61,12 +61,10 @@ public class Endpoint : TestBase<App>
         {
             Email = req.Email,
             PasswordHash = "hashedPassword",
-            VerificationToken = "verificationToken",
-            RoleId = fakeRoleRepository.Retrieve(fakeRole.Name).Result!.Id
         };
 
 
-        A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).Returns((User?)null);
+        A.CallTo(() => fakeUserRepository.RetrieveByEmail(req.Email.ToLowerInvariant())).Returns((User?)null);
         A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).Returns(fakeRole);
         A.CallTo(() => fakeMemberRepository.Create(member)).Returns(member.Id);
         A.CallTo(() => fakeUserRepository.Create(user)).Returns(user.Id);
@@ -87,68 +85,9 @@ public class Endpoint : TestBase<App>
 
 
     [Fact]
-    public async Task RegisterUserFailureInvalidRequest()
+    public async Task RegisterUserFailure_UserAlreadyExists()
     {
         // ToDo does not work yet
-        // Arrange
-        var fakeMemberRepository = A.Fake<IMembers>();
-        var fakeUserRepository = A.Fake<IUsers>();
-        var fakeRoleRepository = A.Fake<IRoles>();
-        var fakeEmailService = A.Fake<IEmailService>();
-        var fakeLogger = A.Fake<ILogger<Endpoint>>();
-
-        var req = new Request
-        {
-            Email = "invalidEmail",
-            Password = "notsafe987",
-            FirstName = "testFName",
-            LastName = "testLName",
-            Street = "test",
-            HouseNumber = "test",
-            PostalCode = "test",
-            City = "test",
-            Country = "test",
-            BirthDate = new DateOnly(2024, 1, 1),
-            BirthPlace = "test",
-            PhoneNumber = "test"
-        };
-
-
-        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
-        {
-            ctx.AddTestServices(s =>
-            {
-                s.AddSingleton(fakeUserRepository);
-                s.AddSingleton(fakeMemberRepository);
-                s.AddSingleton(fakeRoleRepository);
-                s.AddSingleton(fakeEmailService);
-                s.AddSingleton(fakeLogger);
-            });
-        });
-
-        var member = ep.Map.ToEntity(req);
-
-
-        A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email.ToLowerInvariant())).Returns((User?)null);
-
-
-        // Act
-        await ep.HandleAsync(req, default);
-        var rsp = ep.HttpContext.Response;
-
-        // Assert
-
-        //A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).MustHaveHappenedOnceExactly();
-        //A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).MustHaveHappenedOnceOrMore();
-        //A.CallTo(() => fakeUserRepository.Create(user)).MustHaveHappenedOnceExactly();
-
-        Assert.NotNull(rsp);
-        Assert.Equal(StatusCodes.Status400BadRequest, rsp.StatusCode);
-    }
-
-    [Fact]
-    public async Task RegisterUserFailureUserAlreadyExists()
-    {
         // Arrange
         var fakeMemberRepository = A.Fake<IMembers>();
         var fakeUserRepository = A.Fake<IUsers>();
@@ -184,14 +123,71 @@ public class Endpoint : TestBase<App>
                 s.AddSingleton(fakeLogger);
             });
         });
-
         var member = ep.Map.ToEntity(req);
+        var user = new User
+        {
+            Email = req.Email,
+            PasswordHash = "hashedPassword",
+        };
+
+        A.CallTo(() => fakeUserRepository.RetrieveByEmail(req.Email.ToLowerInvariant())).Returns(user);
 
 
-        A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email.ToLowerInvariant())).Returns(
-                new User { Email = "test@test.de", PasswordHash = "notsafe987Hash" });
+        // Act
+        await ep.HandleAsync(req, default);
+        var rsp = ep.HttpContext.Response;
+
+        // Assert
+
+        //A.CallTo(() => fakeUserRepository.Retrieve("email", req.Email)).MustHaveHappenedOnceExactly();
+        //A.CallTo(() => fakeRoleRepository.Retrieve(fakeRole.Name)).MustHaveHappenedOnceOrMore();
+        //A.CallTo(() => fakeUserRepository.Create(user)).MustHaveHappenedOnceExactly();
+
+        Assert.NotNull(rsp);
+        Assert.Equal(StatusCodes.Status400BadRequest, rsp.StatusCode);
+    }
 
 
+    [Fact]
+    public async Task RegisterUserFailure_InvalidRequest()
+    {
+        // Arrange
+        var fakeMemberRepository = A.Fake<IMembers>();
+        var fakeUserRepository = A.Fake<IUsers>();
+        var fakeRoleRepository = A.Fake<IRoles>();
+        var fakeEmailService = A.Fake<IEmailService>();
+        var fakeLogger = A.Fake<ILogger<Endpoint>>();
+
+        var req = new Request
+        {
+            Email = "notAValidEmail",
+            Password = "notsafe987",
+            FirstName = "testFName",
+            LastName = "testLName",
+            Street = "test",
+            HouseNumber = "test",
+            PostalCode = "test",
+            City = "test",
+            Country = "test",
+            BirthDate = new DateOnly(2024, 12, 12),
+            BirthPlace = "test",
+            PhoneNumber = "test"
+        };
+
+
+        var ep = Factory.Create<Features.Users.Endpoints.Post.Register.Endpoint>(ctx =>
+        {
+            ctx.AddTestServices(s =>
+            {
+                s.AddSingleton(fakeUserRepository);
+                s.AddSingleton(fakeMemberRepository);
+                s.AddSingleton(fakeRoleRepository);
+                s.AddSingleton(fakeEmailService);
+                s.AddSingleton(fakeLogger);
+            });
+        });
+
+        A.CallTo(() => fakeUserRepository.RetrieveByEmail(req.Email.ToLowerInvariant())).Returns((User?)null);
         // Act
         await ep.HandleAsync(req, default);
         var rsp = ep.HttpContext.Response;


### PR DESCRIPTION
[User story 139](https://tree.taiga.io/project/julius-boettger-voycar/us/139)


In diesen Unittests wird für den Register-Endpoint überprüft, ob er die entsprechenden Statuscodes (200,400) liefert. Die Request-Validation sollte in einem Integrationtest überprüft werden.
