### PR TITLE
us-85 SMTP credentials beim Test sollten aus .env geladen werden

### DIFF
--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -12,6 +12,10 @@ using Voycar.Api.Web.Service;
 
 try
 {
+    // Load .env file from current directory
+    // If there is none: search parent directories
+    DotNetEnv.Env.TraversePath().Load();
+
     var builder = WebApplication.CreateBuilder(args);
 
     builder.Host.UseSerilog((context, configuration) =>

--- a/Voycar.Api.Web/Service/EmailService.cs
+++ b/Voycar.Api.Web/Service/EmailService.cs
@@ -12,9 +12,9 @@ using Entities;
 /// </summary>
 public class EmailService : IEmailService
 {
-    private readonly string? SmtpEmail  = Environment.GetEnvironmentVariable("SmtpEmail");
     private readonly string? SmtpAppPassword = Environment.GetEnvironmentVariable("SmtpAppPassword");
 
+    private const string SmtpEmail = "voycar.dev@gmail.com";
     private const string SmtpHostAddress = "smtp.gmail.com";
     private const int SmtpPort = 587;
 
@@ -50,13 +50,13 @@ public class EmailService : IEmailService
 
     private void ConfigureSmtpClient(SmtpClient smtpClient)
     {
-        if (string.IsNullOrEmpty(this.SmtpEmail) || string.IsNullOrEmpty(this.SmtpAppPassword))
+        if (string.IsNullOrEmpty(SmtpEmail) || string.IsNullOrEmpty(this.SmtpAppPassword))
         {
             throw new InvalidOperationException("SMTP email or password environment variables are not set.");
         }
 
         smtpClient.Connect(SmtpHostAddress, SmtpPort, SecureSocketOptions.StartTls);
-        smtpClient.Authenticate(this.SmtpEmail, this.SmtpAppPassword);
+        smtpClient.Authenticate(SmtpEmail, this.SmtpAppPassword);
     }
 
 
@@ -77,7 +77,7 @@ public class EmailService : IEmailService
     private MimeMessage CreateVerificationEmail(User user, string verificationLink)
     {
         var email = new MimeMessage();
-        email.From.Add(MailboxAddress.Parse(this.SmtpEmail));
+        email.From.Add(MailboxAddress.Parse(SmtpEmail));
         email.To.Add(MailboxAddress.Parse(user.Email));
         email.Subject = "Voycar-Konto-Verifizierung";
 
@@ -98,7 +98,7 @@ public class EmailService : IEmailService
     private MimeMessage CreatePasswordResetEmail(User user, string passwordResetLink)
     {
         var email = new MimeMessage();
-        email.From.Add(MailboxAddress.Parse(this.SmtpEmail));
+        email.From.Add(MailboxAddress.Parse(SmtpEmail));
         email.To.Add(MailboxAddress.Parse(user.Email));
         email.Subject = "Voycar-Passwort-Reset";
 

--- a/Voycar.Api.Web/Voycar.Api.Web.csproj
+++ b/Voycar.Api.Web/Voycar.Api.Web.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3"/>
+    <PackageReference Include="DotNetEnv" Version="3.0.0" />
     <PackageReference Include="FastEndpoints" Version="5.26.0"/>
     <PackageReference Include="FastEndpoints.Security" Version="5.26.0"/>
     <PackageReference Include="FastEndpoints.Swagger" Version="5.26.0"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@
       - .env
     environment:
       ConnectionStrings__VoycarDb: User ID=admin;Password=admin;Server=voycar.postgres;Port=5432;Database=VoycarDb;
-      SmtpEmail: voycar.dev@gmail.com
     depends_on:
       - voycar.postgres
 


### PR DESCRIPTION
[User story 85](https://tree.taiga.io/project/julius-boettger-voycar/us/85)

Ich habe ausprobiert, dass das funktioniert, wenn man...
- Das Backend lokal startet
- `docker compose up` macht
- Die Integrationstests ausführt

Ich wollte eigentlich auch noch das Laden der `.env`-Datei aus der `docker-compose.yaml` nehmen, weil ich dachte, das ist jetzt redundant, wenn wirs im C# Code machen. Geht aber dann nicht. Ich vermute, weil die `.env`-Datei nicht mit in den Container kopiert wird... Hab ich kurz versucht zu fixen, ging auch nicht, also bleibts erstmal so drin. Funktioniert so und schadet nicht.