### PR TITLE
us-177 "Reservation"-Feature zu "Reservations" unbennen

### DIFF
--- a/Voycar.Api.Web/Features/Reservation/Repository/IReservations.cs
+++ b/Voycar.Api.Web/Features/Reservation/Repository/IReservations.cs
@@ -1,5 +1,0 @@
-namespace Voycar.Api.Web.Features.Reservation.Repository;
-
-using Entities;
-
-public interface IReservations : Generic.Repository.IRepository<Reservation>;

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Delete/Single.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Delete/Single.cs
@@ -1,7 +1,7 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Delete;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Delete;
 
-using Entities;
 using Repository;
+using Entities;
 
 public class Single : Generic.Endpoint.Delete.Single<Reservation>
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Get/All.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Get/All.cs
@@ -1,7 +1,7 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Get;
 
-using Entities;
 using Repository;
+using Entities;
 
 public class All : Generic.Endpoint.Get.All<Reservation>
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Endpoint.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Endpoint.cs
@@ -2,7 +2,7 @@ namespace Voycar.Api.Web.Features.Reservations.Endpoints.Get.Personal;
 
 using Repository;
 using Entities;
-using Voycar.Api.Web.Features.Users.Repository;
+using Users.Repository;
 
 public class Endpoint : Endpoint<Request, Results<Ok<Response>, BadRequest<string>>>
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Endpoint.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Endpoint.cs
@@ -1,9 +1,8 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get.Personal;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Get.Personal;
 
-using Entities;
 using Repository;
-using Users.Repository;
-
+using Entities;
+using Voycar.Api.Web.Features.Users.Repository;
 
 public class Endpoint : Endpoint<Request, Results<Ok<Response>, BadRequest<string>>>
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Request.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Request.cs
@@ -1,4 +1,4 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get.Personal;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Get.Personal;
 
 public class Request
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Response.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Personal/Response.cs
@@ -1,7 +1,6 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get.Personal;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Get.Personal;
 
 using Entities;
-
 
 public class Response
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Single.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Get/Single.cs
@@ -1,7 +1,7 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Get;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Get;
 
-using Entities;
 using Repository;
+using Entities;
 
 public class Single : Generic.Endpoint.Get.Single<Reservation>
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Post/SingleUnique.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Post/SingleUnique.cs
@@ -1,7 +1,7 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Post;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Post;
 
-using Entities;
 using Repository;
+using Entities;
 
 public class SingleUnique : Generic.Endpoint.Post.SingleUnique<Reservation>
 {

--- a/Voycar.Api.Web/Features/Reservations/Endpoints/Put/Single.cs
+++ b/Voycar.Api.Web/Features/Reservations/Endpoints/Put/Single.cs
@@ -1,7 +1,7 @@
-namespace Voycar.Api.Web.Features.Reservation.Endpoints.Put;
+namespace Voycar.Api.Web.Features.Reservations.Endpoints.Put;
 
-using Entities;
 using Repository;
+using Entities;
 
 public class Single : Generic.Endpoint.Put.Single<Reservation>
 {

--- a/Voycar.Api.Web/Features/Reservations/Repository/IReservations.cs
+++ b/Voycar.Api.Web/Features/Reservations/Repository/IReservations.cs
@@ -1,5 +1,5 @@
 namespace Voycar.Api.Web.Features.Reservations.Repository;
 
-using Voycar.Api.Web.Entities;
+using Entities;
 
 public interface IReservations : Generic.Repository.IRepository<Reservation>;

--- a/Voycar.Api.Web/Features/Reservations/Repository/IReservations.cs
+++ b/Voycar.Api.Web/Features/Reservations/Repository/IReservations.cs
@@ -1,0 +1,5 @@
+namespace Voycar.Api.Web.Features.Reservations.Repository;
+
+using Voycar.Api.Web.Entities;
+
+public interface IReservations : Generic.Repository.IRepository<Reservation>;

--- a/Voycar.Api.Web/Features/Reservations/Repository/Reservations.cs
+++ b/Voycar.Api.Web/Features/Reservations/Repository/Reservations.cs
@@ -1,7 +1,7 @@
-namespace Voycar.Api.Web.Features.Reservation.Repository;
+namespace Voycar.Api.Web.Features.Reservations.Repository;
 
-using Context;
-using Entities;
+using Voycar.Api.Web.Context;
+using Voycar.Api.Web.Entities;
 
 public class Reservations : Generic.Repository.Repository<Reservation>, IReservations
 {

--- a/Voycar.Api.Web/Features/Reservations/Repository/Reservations.cs
+++ b/Voycar.Api.Web/Features/Reservations/Repository/Reservations.cs
@@ -1,7 +1,7 @@
 namespace Voycar.Api.Web.Features.Reservations.Repository;
 
-using Voycar.Api.Web.Context;
-using Voycar.Api.Web.Entities;
+using Context;
+using Entities;
 
 public class Reservations : Generic.Repository.Repository<Reservation>, IReservations
 {

--- a/Voycar.Api.Web/Program.cs
+++ b/Voycar.Api.Web/Program.cs
@@ -5,7 +5,7 @@ using Voycar.Api.Web.Features.Cities.Repository;
 using Voycar.Api.Web.Features.Roles.Repository;
 using Voycar.Api.Web.Features.Members.Repository;
 using Voycar.Api.Web.Features.Plans.Repository;
-using Voycar.Api.Web.Features.Reservation.Repository;
+using Voycar.Api.Web.Features.Reservations.Repository;
 using Voycar.Api.Web.Features.Stations.Repository;
 using Voycar.Api.Web.Features.Users.Repository;
 using Voycar.Api.Web.Service;


### PR DESCRIPTION
[User story 177](https://tree.taiga.io/project/julius-boettger-voycar/us/177)

Rider hat automatisch irgendwelche Imports umsortiert.
Und Github hat zuerst was komisch angezeigt, weswegen ich die PR kurz geschlossen und jetzt wieder geöffnet habe.