### PR TITLE
us-189 Parallele Ausführung von Integrationstests fixen

### DIFF
--- a/Voycar.Api.Web.Tests.Integration/App.cs
+++ b/Voycar.Api.Web.Tests.Integration/App.cs
@@ -8,6 +8,14 @@ using Setup;
 using DotNet.Testcontainers.Builders;
 using Testcontainers.PostgreSql;
 
+/* Normally the SUT (API and database) will only be created once for all test-classes and cached afterward.
+ Disabling the WAF cache will create a new instance for every test-class resulting in worse test performance.
+ This behaviour is intended so that test-classes can perform operations on the database without impacting
+ any other tests which assert the content of the database.
+ See: https://fast-endpoints.com/docs/integration-unit-testing#app-fixture
+ See: https://gist.github.com/dj-nitehawk/04a78cea10f2239eb81c958c52ec84e0
+*/
+[DisableWafCache]
 public class App : AppFixture<Program>
 {
     /* Change this constant to true, to test against production database
@@ -20,7 +28,6 @@ public class App : AppFixture<Program>
     public HttpClient Employee { get; private set; }
     public HttpClient Admin { get; private set; }
 
-    // See: https://gist.github.com/dj-nitehawk/04a78cea10f2239eb81c958c52ec84e0
     protected override async Task PreSetupAsync()
     {
         if (TestAgainstProductionDb)

--- a/Voycar.Api.Web.Tests.Integration/App.cs
+++ b/Voycar.Api.Web.Tests.Integration/App.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Context;
 using Setup;
-using DotNet.Testcontainers.Builders;
 using Testcontainers.PostgreSql;
 
 /* Normally the SUT (API and database) will only be created once for all test-classes and cached afterward.

--- a/Voycar.Api.Web.Tests.Integration/App.cs
+++ b/Voycar.Api.Web.Tests.Integration/App.cs
@@ -28,8 +28,10 @@ public class App : AppFixture<Program>
     public HttpClient Employee { get; private set; }
     public HttpClient Admin { get; private set; }
 
-    protected override async Task PreSetupAsync()
+    protected override async Task SetupAsync()
     {
+        // == Place one-time setup code here ==
+
         if (TestAgainstProductionDb)
         {
             // WARNING: This will test against production database and DELETE existing data
@@ -48,11 +50,6 @@ public class App : AppFixture<Program>
             .Build();
         await this.Container.StartAsync();
         this.ConnectionString = this.Container.GetConnectionString();
-    }
-
-    protected override async Task SetupAsync()
-    {
-        // == Place one-time setup code here ==
 
         // Set up Db for tests
         this.Context = this.Services.GetRequiredService<VoycarDbContext>();

--- a/Voycar.Api.Web.Tests.Integration/App.cs
+++ b/Voycar.Api.Web.Tests.Integration/App.cs
@@ -7,10 +7,11 @@ using Context;
 using Setup;
 using Testcontainers.PostgreSql;
 
-/* Normally the SUT (API and database) will only be created once for all test-classes and cached afterward.
- Disabling the WAF cache will create a new instance for every test-class resulting in worse test performance.
- This behaviour is intended so that test-classes can perform operations on the database without impacting
- any other tests which assert the content of the database.
+/*
+Usually, the SUT (API and database) will only be created once for all test classes and cached afterward.
+ Disabling the WAF cache will create a new instance for every test class, resulting in worse test performance.
+ This behavior is intended so that test classes can perform operations on the database without impacting
+ any other tests that assert the content of the database.
  See: https://fast-endpoints.com/docs/integration-unit-testing#app-fixture
  See: https://gist.github.com/dj-nitehawk/04a78cea10f2239eb81c958c52ec84e0
 */


### PR DESCRIPTION
[User story 189](https://tree.taiga.io/project/julius-boettger-voycar/us/189)
Die Integrationstests können jetzt alle gleichzeitig ausgeführt werden. Habe versucht mit Kommentar und commit messasges zu erklären, was das macht und warum es so besser ist.
